### PR TITLE
Add 7S battery support

### DIFF
--- a/Mower Arduino Code/Mower_V9.2/MEGA_V9.2/AmpsVolts.ino
+++ b/Mower Arduino Code/Mower_V9.2/MEGA_V9.2/AmpsVolts.ino
@@ -145,9 +145,9 @@ if (Show_TX_Data == 1) {
 
  if (RawValueVolt > 100)  {
  float vout = 0.0;
- float R1 = 30000;      // Mower 330 = 30000    Mower LAM = 30000
+ float R1 = 30000;      // Voltage divider top resistor (30k)
  //float R2 = 7000;       // Mower 330 = 7000     
- float R2 = 7500;       // Mower LAM = 6500
+ float R2 = 5900;       // Bottom resistor (5.9k) for 7S battery up to 29.4V
  vout = (RawValueVolt * 5.0) / 1024.0; // see text
  Volts = vout / (R2/(R1+R2));
  Volts_Last = Volts;

--- a/Mower Arduino Code/Mower_V9.2/MEGA_V9.2/MEGA_V9.2.ino
+++ b/Mower Arduino Code/Mower_V9.2/MEGA_V9.2/MEGA_V9.2.ino
@@ -124,6 +124,12 @@ DS1302 rtc(kCePin, kIoPin, kSclkPin);
 // Tilt Sensors
 #define Tilt_Angle A8           // measures the angle of the mower
 #define Tilt_Orientation A9     // measures if the mower is upside down
+// Analog sensor pins (direct connection without Nano)
+#define AMP_SENSOR_PIN   A10
+#define VOLT_SENSOR_PIN  A11
+#define RAIN_SENSOR_PIN  A12
+#define WHEEL_AMP_PIN    A13
+
 
 
 //Global Variables
@@ -476,7 +482,7 @@ DS1302 rtc(kCePin, kIoPin, kSclkPin);
   int  Rain_Total_Hits_Go_Home        = 10; //EEPROM            // This sensor only makes sense in combination with a mower docking station
                                                                 // as the mower is sent there to get out of the rain.
   //Battery Settings
-  float Battery_Max               = 12.6;                       // Max battery volts in Volts. 3S = 12.6V
+  float Battery_Max               = 29.4;                       // Max battery volts in Volts. 7S = 29.4V
   float Battery_Min               = 11.4;   //EEPROM            // Lower Limit of battery charge before re-charge required.
   byte  Low_Battery_Detected      = 0;                          // Always set to 0
   byte  Low_Battery_Instances_Chg = 14;     //EEPROM            // Instances of low battery detected before a re-charge is called..
@@ -641,7 +647,7 @@ if (TFT_Screen_Menu == 1)                                 Check_TFT_Serial_Input
 if ((TFT_Screen_Menu == 1) && (TFT_Menu_Command > 1))     Activate_TFT_Menu();        // If TFT Menu has requested an input, TX or RX that input.
 
 // Read the Serial Ports for Data
-Read_Serial1_Nano();                                                                  // Read the Serial data from the nano
+Read_Analog_Sensors_Mega();                                                                  // Read analog sensor data
 Print_Mower_Status();                                                                 // Update the Serial monitor with the current mower status.
 
 

--- a/Mower Arduino Code/Mower_V9.2/MEGA_V9.2/Menu_Sensors.ino
+++ b/Mower Arduino Code/Mower_V9.2/MEGA_V9.2/Menu_Sensors.ino
@@ -450,7 +450,7 @@ void Activate_Menu_Option_Sensors() {
              }
              if (!Plus_Key_X) {
                Battery_Min = Battery_Min + 0.1;
-               if (Battery_Min > 12.6) Battery_Min = 12.6;
+               if (Battery_Min > 29.4) Battery_Min = 29.4;
                lcd.setCursor(0,1);
                lcd.print("      ");    // Fully clear the number to stop reminants of a previous number from being left behind
                lcd.setCursor(0,1);
@@ -461,7 +461,7 @@ void Activate_Menu_Option_Sensors() {
                }
              if (!Minus_Key_X) {
                Battery_Min = Battery_Min - 0.1;
-               if (Battery_Min < 10.5) Battery_Min = 10.5;
+               if (Battery_Min < 21.0) Battery_Min = 21.0;
                lcd.setCursor(0,1);
                lcd.print("      ");   // Fully clear the number to stop reminants of a previous number from being left behind
                lcd.setCursor(0,1);

--- a/Mower Arduino Code/Mower_V9.2/MEGA_V9.2/Menu_Testing.ino
+++ b/Mower Arduino Code/Mower_V9.2/MEGA_V9.2/Menu_Testing.ino
@@ -236,7 +236,7 @@ void Activate_Menu_Option_Testing() {
         Menu_Complete = false;
         while (Menu_Complete == false) {
           Read_Membrane_Keys();
-          Read_Serial1_Nano();
+          Read_Analog_Sensors_Mega();
           delay(100);
           Serial.print(F("  Charging:"));
           Serial.print(Charging);

--- a/Mower Arduino Code/Mower_V9.2/MEGA_V9.2/TFT_TX.ino
+++ b/Mower Arduino Code/Mower_V9.2/MEGA_V9.2/TFT_TX.ino
@@ -799,7 +799,7 @@ void Send_Data_To_TFT() {
 
         if (i > 28) Test_Complete = 1;
         
-        Read_Serial1_Nano();
+        Read_Analog_Sensors_Mega();
         delay(200);
 
         int VoltsRX = (Volts * 100) / 2;

--- a/Mower Arduino Code/Mower_V9.2/MEGA_V9.2/TXRX_NANO.ino
+++ b/Mower Arduino Code/Mower_V9.2/MEGA_V9.2/TXRX_NANO.ino
@@ -34,3 +34,15 @@ void Read_Serial1_Nano() {
 Calculate_Volt_Amp_Charge();
 
 }
+
+// Read analog sensors directly when no Nano is used
+void Read_Analog_Sensors_Mega() {
+  RawValueAmp   = analogRead(AMP_SENSOR_PIN);
+  RawValueVolt  = analogRead(VOLT_SENSOR_PIN);
+  Rain_Detected = analogRead(RAIN_SENSOR_PIN);
+  RawWheelAmp   = analogRead(WHEEL_AMP_PIN);
+
+  if (Rain_Detected < 100) Rain_Detected = 0; else Rain_Detected = 1;
+
+  Calculate_Volt_Amp_Charge();
+}

--- a/Mower Arduino Code/Mower_V9.2/MEGA_V9.2/Test_Mower_Sketches.ino
+++ b/Mower Arduino Code/Mower_V9.2/MEGA_V9.2/Test_Mower_Sketches.ino
@@ -77,7 +77,7 @@ void Test_Wheel_Amps () {
     SetPins_ToGoForwards();
     Motor_Action_Go_Full_Speed();
       for (int i = 0; i <= 100; i++) {
-        Read_Serial1_Nano(); 
+        Read_Analog_Sensors_Mega(); 
         Calculate_Wheel_Amps();
         Test_Check_Wheel_Amps();             
         Send_Wheel_Amp_Data();

--- a/Mower Arduino Code/Mower_V9.2/MEGA_V9.2/Wire_Tracking.ino
+++ b/Mower Arduino Code/Mower_V9.2/MEGA_V9.2/Wire_Tracking.ino
@@ -444,7 +444,7 @@ void Track_Perimeter_Wire_To_Dock()  {
       }
       Serial.print(F(" : MAG_Error="));
       Serial.print(MAG_Error);
-      Read_Serial1_Nano();
+      Read_Analog_Sensors_Mega();
       Check_if_Charging();
       Check_if_Docked();
       Dock_Cycles = Dock_Cycles + 1;
@@ -556,7 +556,7 @@ void Track_Perimeter_Wire_To_Dock()  {
       }
       Serial.print(F(" : MAG_Error="));
       Serial.print(MAG_Error);
-      Read_Serial1_Nano();
+      Read_Analog_Sensors_Mega();
       Check_if_Charging();
       Check_if_Docked();
       Dock_Cycles = Dock_Cycles + 1;

--- a/Mower Arduino Code/Mower_V9.2/Nano_V8.6/Nano_V8.6.ino
+++ b/Mower Arduino Code/Mower_V9.2/Nano_V8.6/Nano_V8.6.ino
@@ -55,8 +55,8 @@ void Calculate_Volt_Amp() {
 // Calculate Voltage Sensor Value from Battery
  
  float vout = 0.0;
- float R1 = 30000;      // 30000 Mower 2    Mower 1 30000
- float R2 = 7500;       // 7300 Mower 2     Mower 1 7500
+ float R1 = 30000;      // Voltage divider top resistor (30k)
+ float R2 = 5900;       // Bottom resistor (5.9k) for 7S battery up to 29.4V
  vout = (RawValueVolt * 5.0) / 1024.0; // see text
  VoltsTX = vout / (R2/(R1+R2)); 
 

--- a/Readme.txt
+++ b/Readme.txt
@@ -47,3 +47,5 @@ Ihe idea is to debug the components indicudually so you are faster in completing
 ----------------------------------------------
 All my work falls under the GNU Public License
 ----------------------------------------------
+
+This version adds support for using a 7S battery pack. The voltage divider has been updated to 30k/5.9k and analog readings can now be taken directly from the MEGA without a Nano.


### PR DESCRIPTION
## Summary
- update voltage divider for 7S batteries
- add analog sensor pin definitions for the Mega
- allow Mega to read volt/amp sensors directly
- update battery settings menu limits
- document new battery option

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840255675548330a72a9f8110a14d10